### PR TITLE
Fixed issue where tags at the beginning of summary not parsed correctly.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tests/test_repo2"]
 	path = tests/test_repo2
 	url = https://github.com/saschagrunert/test2
+[submodule "tests/test_repo3"]
+	path = tests/test_repo3
+	url = git@github.com:jwir3/ghp-release-cleaner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1011,6 +1011,20 @@ mod tests {
     }
 
     #[test]
+    fn output_correctly_categorized() {
+      let mut journal = GitJournal::new("./tests/test_repo3").unwrap();
+      assert!(journal
+          .parse_log("444b3a64355557844beb848d80051ada2c00176a..HEAD", "rc", 0, true, false, None, None)
+          .is_ok());
+      assert_eq!(journal.parser.result.len(), 4);
+      assert_eq!(journal.parser.result[0].name, "Unreleased");
+      assert_eq!(journal.parser.result[0].commits.len(), 3);
+      assert_eq!(journal.parser.result[0].commits[0].summary.tags.len(), 2);
+      assert!(journal.print_log(false, None, Some("CHANGELOG.md")).is_ok());
+      assert!(journal.print_log(true, None, Some("CHANGELOG.md")).is_ok());
+    }
+
+    #[test]
     fn path_failure() {
         assert!(GitJournal::new("/etc/").is_err());
     }


### PR DESCRIPTION
If tags appeared before the category when parsing, the tags would not be
added to the list of tags in the commit message. This was due, in part, to
a regular expression that did not consider the possibility that the tag
could be at the beginning of a line, and partially due to the fact that
tags were only parsed from the remainder of the line AFTER categories had
been removed.

Fixes #928.